### PR TITLE
[GRMP-56] Systest Failure: 'test_chunked_download'.

### DIFF
--- a/tests/system/requests/test_download.py
+++ b/tests/system/requests/test_download.py
@@ -63,12 +63,12 @@ ALL_FILES = (
     }, {
         u'path': os.path.realpath(os.path.join(DATA_DIR, u'gzipped.txt.gz')),
         u'uncompressed':
-            os.path.realpath(os.path.join(DATA_DIR, u'gzipped.txt')),
+            os.path.realpath(os.path.join(DATA_DIR, u'gzipped.txt.gz')),
         u'content_type': PLAIN_TEXT,
         u'checksum': u'KHRs/+ZSrc/FuuR4qz/PZQ==',
         u'slices': (),
         u'metadata': {
-            u'contentEncoding': u'gzip',
+            u'Content-Encoding': u'gzip',
         },
     },
 )
@@ -76,6 +76,7 @@ ENCRYPTED_ERR = (
     b'The target object is encrypted by a customer-supplied encryption key.')
 NO_BODY_ERR = (
     u'The content for this response was already consumed')
+
 NOT_FOUND_ERR = (
     b'No such object: ' +
     utils.BUCKET_NAME.encode('utf-8') +

--- a/tests/system/requests/test_download.py
+++ b/tests/system/requests/test_download.py
@@ -395,7 +395,6 @@ def consume_chunks(download, authorized_transport,
     return num_responses, response
 
 
-@pytest.mark.xfail  # See issue #56
 def test_chunked_download(add_files, authorized_transport):
     for info in ALL_FILES:
         actual_contents = _get_contents(info)


### PR DESCRIPTION
Addresses [GRMP-56](https://github.com/googleapis/google-resumable-media-python/issues/56)
- fix syntax error, Due to system tests  run with different versions of python